### PR TITLE
feat(today): added new possibilities to pass today

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ yarn start
 
 1. **_`DOMElement`_**: DOM element to which the calendar should be attached (es. body, #app)
 
-2. **_`today`_**: Pass today from the parent application, so calendar can avoid to adapt itself to internalization and/or timezones.
+2. **_`today`_**: Pass today from the parent application, so calendar can avoid to adapt itself to internalization and/or timezones. Today could be a js `Date`, a string formatted with `YYYY/MM/DD` or an object `{ year, month, day }`
 
 3. **_`initialDate`_**: selected date to fit calendar to the right month/year on the splash screen
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,12 @@
 import { letterWeekDays } from "./js/constants/weekdays";
 import { letterMonths } from "./js/constants/months";
 import { renderCalendarBlocks } from "./js/builder/calendar";
-import { differenceInDays, dateInRange, addDays } from "./js/helpers/index";
+import {
+  differenceInDays,
+  dateInRange,
+  addDays,
+  formatToday,
+} from "./js/helpers/index";
 import "./css/index.scss";
 
 class CalendarInitiator {
@@ -49,7 +54,7 @@ class CalendarInitiator {
     maxCheckin = 30,
   } = {}) {
     this.#DOMElement = DOMElement;
-    this.#today = today;
+    this.#today = formatToday(today);
     this.#initialDate = initialDate;
     this.#weekdaysLabels = weekdaysLabels;
     this.#monthsLabels = monthsLabels;

--- a/src/js/helpers/index.js
+++ b/src/js/helpers/index.js
@@ -33,3 +33,22 @@ export const addDays = (date, days) => {
   const updateDate = newDate.setDate(newDate.getDate() + days);
   return new Date(updateDate);
 };
+
+export const formatToday = (today) => {
+  if (today instanceof Date) return today;
+
+  if (typeof today === "string") {
+    const stringReg = /^\d{4}[/]\d{2}[/]\d{2}$/;
+    const isValidString = stringReg.matches(today);
+    if (isValidString) return new Date(today);
+    else return new Date();
+  }
+
+  if (typeof today === "object") {
+    if (today.year && today.month && today.day) {
+      return new Date(year, month, day);
+    }
+  }
+
+  return new Date();
+};


### PR DESCRIPTION
Now today could be 

- a date
- a string formatted `YYYY/MM/DD`
- an object `{ year, month, day }`